### PR TITLE
fix: fix bug of api_token. Add extra statement to check if the value is null

### DIFF
--- a/examples/cloudflare-bastion-tunnel-and-gsm/variables.tf
+++ b/examples/cloudflare-bastion-tunnel-and-gsm/variables.tf
@@ -8,7 +8,7 @@ variable "api_token" {
   sensitive   = true
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_-]{40}$", var.api_token))
+    condition     = var.api_token == null || can(regex("^[a-zA-Z0-9_-]{40}$", var.api_token))
     error_message = "API Token must be 40 characters long and only contain characters a-z, A-Z, 0-9, hyphens and underscores."
   }
 }

--- a/examples/tunnel-with-virtual-networks-and-routing/variables.tf
+++ b/examples/tunnel-with-virtual-networks-and-routing/variables.tf
@@ -8,7 +8,7 @@ variable "api_token" {
   sensitive   = true
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_-]{40}$", var.api_token))
+    condition     = var.api_token == null || can(regex("^[a-zA-Z0-9_-]{40}$", var.api_token))
     error_message = "API Token must be 40 characters long and only contain characters a-z, A-Z, 0-9, hyphens and underscores."
   }
 }

--- a/modules/tunnel-route/variables.tf
+++ b/modules/tunnel-route/variables.tf
@@ -8,7 +8,7 @@ variable "api_token" {
   sensitive   = true
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_-]{40}$", var.api_token))
+    condition     = var.api_token == null || can(regex("^[a-zA-Z0-9_-]{40}$", var.api_token))
     error_message = "API Token must be 40 characters long and only contain characters a-z, A-Z, 0-9, hyphens and underscores."
   }
 }

--- a/modules/virtual-network/variables.tf
+++ b/modules/virtual-network/variables.tf
@@ -8,7 +8,7 @@ variable "api_token" {
   sensitive   = true
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_-]{40}$", var.api_token))
+    condition     = var.api_token == null || can(regex("^[a-zA-Z0-9_-]{40}$", var.api_token))
     error_message = "API Token must be 40 characters long and only contain characters a-z, A-Z, 0-9, hyphens and underscores."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,7 +8,7 @@ variable "api_token" {
   sensitive   = true
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_-]{40}$", var.api_token))
+    condition     = var.api_token == null || can(regex("^[a-zA-Z0-9_-]{40}$", var.api_token))
     error_message = "API Token must be 40 characters long and only contain characters a-z, A-Z, 0-9, hyphens and underscores."
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable -->

Closes #6 

<!-- Link to an issue(s) this PR fixes -->

#### Summary

Fix the bug of api_token variable. We don't need to run validation when the value is null.

#### Checklist

- [x] Check locally
- [x] Add tests
- [x] Add documentation

<!-- markdownlint restore -->
